### PR TITLE
Add ability to filter by jsonPath.

### DIFF
--- a/Remora.Rest/Extensions/JsonExtensions.cs
+++ b/Remora.Rest/Extensions/JsonExtensions.cs
@@ -1,0 +1,62 @@
+﻿//
+//  JsonExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Buffers;
+using System.Text.Json;
+
+namespace Remora.Rest.Extensions
+{
+    /// <summary>
+    /// Provides extension classes for deserializing <see cref="JsonElement"/>s and <see cref="JsonDocument"/>.
+    /// </summary>
+    /// <remarks>
+    /// As per the <see href="https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to?pivots=dotnet-5-0#serialize-to-utf-8">docs</see>,
+    /// serializing to UTF-8 is about 5-10% faster than using string-based methods. The difference is because bytes (as UTF-8) don't need to be converted to strings (UTF-16).
+    /// </remarks>
+    public static class JsonExtensions
+    {
+        /// <summary>
+        /// Deserializes the current <see cref="JsonElement"/> to the specified <see cref="TEntity"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type to return.</typeparam>
+        /// <param name="element">The <see cref="JsonElement"/> to deserialize.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/>.</param>
+        /// <returns>The converted <see cref="TEntity"/> object or null.</returns>
+        public static TEntity? ToObject<TEntity>(this JsonElement element, JsonSerializerOptions? options = null)
+        {
+            var bufferWriter = new ArrayBufferWriter<byte>();
+            using var writer = new Utf8JsonWriter(bufferWriter);
+            element.WriteTo(writer);
+            return JsonSerializer.Deserialize<TEntity>(bufferWriter.WrittenSpan, options);
+        }
+
+        /// <summary>
+        /// Deserializes the current <see cref="JsonDocument"/> to the specified <see cref="TEntity"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">The type to return.</typeparam>
+        /// <param name="document">The <see cref="JsonDocument"/> to deserialize.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/>.</param>
+        /// <returns>The converted <see cref="TEntity"/> object or null.</returns>
+        public static TEntity? ToObject<TEntity>(this JsonDocument document, JsonSerializerOptions? options = null)
+            => document.RootElement.ToObject<TEntity>(options);
+    }
+}

--- a/Remora.Rest/Http/IRestHttpClient.cs
+++ b/Remora.Rest/Http/IRestHttpClient.cs
@@ -68,6 +68,25 @@ namespace Remora.Rest
         /// Performs a GET request to the REST API at the given endpoint.
         /// </summary>
         /// <param name="endpoint">The endpoint.</param>
+        /// <param name="jsonPath">The path to the element to deserialize.</param>
+        /// <param name="configureRequestBuilder">The request builder for the request.</param>
+        /// <param name="allowNullReturn">Whether to allow null return values inside the creation result.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <typeparam name="TEntity">The entity type to retrieve.</typeparam>
+        /// <returns>A retrieval result which may or may not have succeeded.</returns>
+        Task<Result<TEntity>> GetAsync<TEntity>
+        (
+            string endpoint,
+            string jsonPath,
+            Action<RestRequestBuilder>? configureRequestBuilder = null,
+            bool allowNullReturn = false,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// Performs a GET request to the REST API at the given endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint.</param>
         /// <param name="configureRequestBuilder">The request builder for the request.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A retrieval result which may or may not have succeeded.</returns>
@@ -90,6 +109,25 @@ namespace Remora.Rest
         Task<Result<TEntity>> PostAsync<TEntity>
         (
             string endpoint,
+            Action<RestRequestBuilder>? configureRequestBuilder = null,
+            bool allowNullReturn = false,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// Performs a POST request to the REST API at the given endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint.</param>
+        /// <param name="jsonPath">The path to the element to deserialize.</param>
+        /// <param name="configureRequestBuilder">The request builder for the request.</param>
+        /// <param name="allowNullReturn">Whether to allow null return values inside the creation result.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <typeparam name="TEntity">The entity type to create.</typeparam>
+        /// <returns>A creation result which may or may not have succeeded.</returns>
+        Task<Result<TEntity>> PostAsync<TEntity>
+        (
+            string endpoint,
+            string jsonPath,
             Action<RestRequestBuilder>? configureRequestBuilder = null,
             bool allowNullReturn = false,
             CancellationToken ct = default
@@ -130,6 +168,25 @@ namespace Remora.Rest
         /// Performs a PATCH request to the REST API at the given endpoint.
         /// </summary>
         /// <param name="endpoint">The endpoint.</param>
+        /// <param name="jsonPath">The path to the element to deserialize.</param>
+        /// <param name="configureRequestBuilder">The request builder for the request.</param>
+        /// <param name="allowNullReturn">Whether to allow null return values inside the creation result.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <typeparam name="TEntity">The entity type to modify.</typeparam>
+        /// <returns>A modification result which may or may not have succeeded.</returns>
+        Task<Result<TEntity>> PatchAsync<TEntity>
+        (
+            string endpoint,
+            string jsonPath,
+            Action<RestRequestBuilder>? configureRequestBuilder = null,
+            bool allowNullReturn = false,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// Performs a PATCH request to the REST API at the given endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint.</param>
         /// <param name="configureRequestBuilder">The request builder for the request.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A modification result which may or may not have succeeded.</returns>
@@ -161,6 +218,25 @@ namespace Remora.Rest
         /// Performs a DELETE request to the REST API at the given endpoint.
         /// </summary>
         /// <param name="endpoint">The endpoint.</param>
+        /// <param name="jsonPath">The path to the element to deserialize.</param>
+        /// <param name="configureRequestBuilder">The request builder for the request.</param>
+        /// <param name="allowNullReturn">Whether to allow null return values inside the creation result.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <typeparam name="TEntity">The type of entity to create.</typeparam>
+        /// <returns>A result which may or may not have succeeded.</returns>
+        Task<Result<TEntity>> DeleteAsync<TEntity>
+        (
+            string endpoint,
+            string jsonPath,
+            Action<RestRequestBuilder>? configureRequestBuilder = null,
+            bool allowNullReturn = false,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// Performs a DELETE request to the REST API at the given endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint.</param>
         /// <param name="configureRequestBuilder">The request builder for the request.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A deletion result which may or may not have succeeded.</returns>
@@ -183,6 +259,25 @@ namespace Remora.Rest
         Task<Result<TEntity>> PutAsync<TEntity>
         (
             string endpoint,
+            Action<RestRequestBuilder>? configureRequestBuilder = null,
+            bool allowNullReturn = false,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
+        /// Performs a PUT request to the REST API at the given endpoint.
+        /// </summary>
+        /// <param name="endpoint">The endpoint.</param>
+        /// <param name="jsonPath">The path to the element to deserialize.</param>
+        /// <param name="configureRequestBuilder">The request builder for the request.</param>
+        /// <param name="allowNullReturn">Whether to allow null return values inside the creation result.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <typeparam name="TEntity">The type of entity to create.</typeparam>
+        /// <returns>A result which may or may not have succeeded.</returns>
+        Task<Result<TEntity>> PutAsync<TEntity>
+        (
+            string endpoint,
+            string jsonPath,
             Action<RestRequestBuilder>? configureRequestBuilder = null,
             bool allowNullReturn = false,
             CancellationToken ct = default

--- a/Remora.Rest/Http/RestHttpClient.cs
+++ b/Remora.Rest/Http/RestHttpClient.cs
@@ -21,12 +21,10 @@
 //
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/Remora.Rest/Remora.Rest.csproj
+++ b/Remora.Rest/Remora.Rest.csproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="JsonDocumentPath" Version="1.0.2" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
         <PackageReference Include="OneOf" Version="3.0.190" />
         <PackageReference Include="Remora.Results" Version="7.0.0" />


### PR DESCRIPTION
**What does this do**

Adds the ability to perform requests against a remote API and to provide a Json Path property.

**Why?**

Not all APIs are built the same. Sometimes the data you want is simply what is returned. Other times, it's buried several levels deep. This leaves us with two solutions: building several nested classes to try and replicate what the API gives us or to completely remove any benefit of having Remora.Rest cast the object for us and casting twice:

This double-casting can be avoided by simply allowing users to specify their jsonPath at the time they request the item, as so:
```cs
return await _restClient.GetAsync<SomeType>
(
    endpoint,
    "$[0].data.children[0].data",
    x => x.Build(),
    allowNullReturn,
    cancellationToken
);
```

**Implementation**

In order to maintain backwards compatibility with existing methods, these are added as overloads. The originals are modified to accept a `jsonPath` variable as a string, which it then passes forward to the private `UnpackResponseAsync()` call.

```cs
/// <inheritdoc />
public Task<Result<TEntity>> GetAsync<TEntity>
(
    string endpoint,
    Action<RestRequestBuilder>? configureRequestBuilder = null,
    bool allowNullReturn = false,
    CancellationToken ct = default
)
    => GetAsync<TEntity>(endpoint, string.Empty, configureRequestBuilder, allowNullReturn, ct);
```

Inside `UnpackResponseAsync()`, some logic is added:
```cs
TEntity? entity;

if (string.IsNullOrEmpty(jsonPath))
{
    entity = await JsonSerializer.DeserializeAsync<TEntity>
    (
        contentStream,
        _serializerOptions,
        ct
    );
}
else
{
    var doc = await JsonSerializer.DeserializeAsync<JsonDocument>
    (
        contentStream,
        _serializerOptions,
        ct
    );

    var element = doc.SelectElement(jsonPath);

    if (!element.HasValue)
    {
        return allowNullReturn
            ? Result<TEntity>.FromSuccess(default!)
            : throw new InvalidOperationException("The requested path does not exist or the found content is empty.");
    }

    entity = element.Value.ToObject<TEntity>(_serializerOptions);
}
```

If `string.Empty` is passed, as is default, the method works exactly the same as it used to. If it is not, then the UTF-8 stream is deserialized into a `JsonDocument` (which takes advantage of a speed boost related to avoiding strings), filtered on the requested JsonPath into a specific JsonElement, and then this JsonElement is converted (as UTF-8) into the final requested entity using this extension method:
```
public static TEntity? ToObject<TEntity>(this JsonElement element, JsonSerializerOptions? options = null)
{
    var bufferWriter = new ArrayBufferWriter<byte>();
    using var writer = new Utf8JsonWriter(bufferWriter);
    element.WriteTo(writer);
    return JsonSerializer.Deserialize<TEntity>(bufferWriter.WrittenSpan, options);
}
```