### PR TITLE
Add optional epoch parameter to Snowflake#TryParse

### DIFF
--- a/Remora.Rest.Core/Snowflake.cs
+++ b/Remora.Rest.Core/Snowflake.cs
@@ -94,8 +94,9 @@ namespace Remora.Rest.Core
         /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="result">The result.</param>
+        /// <param name="epoch">The time epoch used for the embedded timestamp.</param>
         /// <returns>true if a snowflake was successfully parsed; otherwise, false.</returns>
-        public static bool TryParse(string value, [NotNullWhen(true)] out Snowflake? result)
+        public static bool TryParse(string value, [NotNullWhen(true)] out Snowflake? result, ulong epoch = 0)
         {
             result = null;
 
@@ -104,7 +105,7 @@ namespace Remora.Rest.Core
                 return false;
             }
 
-            result = new Snowflake(binary);
+            result = new Snowflake(binary, epoch);
 
             return true;
         }

--- a/Remora.Rest/Json/SnowflakeConverter.cs
+++ b/Remora.Rest/Json/SnowflakeConverter.cs
@@ -52,7 +52,7 @@ public class SnowflakeConverter : JsonConverter<Snowflake>
             case JsonTokenType.String:
             {
                 var value = reader.GetString()!;
-                if (!Snowflake.TryParse(value, out var snowflake))
+                if (!Snowflake.TryParse(value, out var snowflake, this.Epoch))
                 {
                     throw new JsonException();
                 }

--- a/Remora.Rest/Json/SnowflakeDictionaryConverter.cs
+++ b/Remora.Rest/Json/SnowflakeDictionaryConverter.cs
@@ -31,6 +31,20 @@ namespace Remora.Rest.Json;
 /// <inheritdoc />
 public class SnowflakeDictionaryConverter<TElement> : JsonConverter<IReadOnlyDictionary<Snowflake, TElement>>
 {
+    /// <summary>
+    /// Gets the epoch used for converting snowflakes.
+    /// </summary>
+    public ulong Epoch { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SnowflakeDictionaryConverter{TElement}"/> class.
+    /// </summary>
+    /// <param name="epoch">The epoch to use.</param>
+    public SnowflakeDictionaryConverter(ulong epoch)
+    {
+        this.Epoch = epoch;
+    }
+
     /// <inheritdoc />
     public override IReadOnlyDictionary<Snowflake, TElement>? Read
     (
@@ -48,7 +62,7 @@ public class SnowflakeDictionaryConverter<TElement> : JsonConverter<IReadOnlyDic
         var mappedDictionary = new Dictionary<Snowflake, TElement>();
         foreach (var (key, element) in dictionary)
         {
-            if (!Snowflake.TryParse(key, out var snowflakeKey))
+            if (!Snowflake.TryParse(key, out var snowflakeKey, this.Epoch))
             {
                 throw new JsonException();
             }

--- a/Tests/Remora.Rest.Core.Tests/Snowflake/SnowflakeTests.cs
+++ b/Tests/Remora.Rest.Core.Tests/Snowflake/SnowflakeTests.cs
@@ -103,6 +103,15 @@ namespace Remora.Rest.Core.Tests.Snowflake
 
                 Assert.Equal(time, snowflake.Timestamp);
             }
+
+            [Fact]
+            public void ReturnsCorrectValueWithEpochParsed()
+            {
+                var time = DateTimeOffset.Parse("2016-02-01T23:59:25.820Z");
+                Core.Snowflake.TryParse("143867839282020352", out var snowflake, 1420070400000);
+
+                Assert.Equal(time, snowflake!.Value.Timestamp);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR was prompted by an issue in Remora.Discord, where snowflakes are being parsed incorrectly due to the epoch not being specified.

Note that I have introduced a slight breaking change by adding a new single constructor to the `SnowflakeDictionaryConverter` which takes an epoch.