### PR TITLE
System.Text.Json on .NET 6 should come from runtime pack.

### DIFF
--- a/Remora.Rest/Remora.Rest.csproj
+++ b/Remora.Rest/Remora.Rest.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
         <PackageReference Include="OneOf" Version="3.0.211" />
         <PackageReference Include="Remora.Results" Version="7.1.1" />
-        <PackageReference Include="System.Text.Json" Version="6.0.2" />
+        <PackageReference Include="System.Text.Json" Version="6.0.2" Condition="'$(TargetFramework)' != 'net6.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Remora.Rest/Remora.Rest.csproj
+++ b/Remora.Rest/Remora.Rest.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JsonDocumentPath" Version="1.0.2" />
+        <PackageReference Include="JsonDocumentPath" Version="1.0.3" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
         <PackageReference Include="OneOf" Version="3.0.211" />
         <PackageReference Include="Remora.Results" Version="7.1.1" />


### PR DESCRIPTION
S.T.J (since stable 6.0.2 is referenced here) should be ignored when targeting .NET 6. This is due to it being included in the Microsoft.NETCore.App runtime bundle which often times includes crucial bug fixes / improvements. As such if newer versions is needed, simply ensure the user's .NET SDK is updated on their end or have them do a property to override the default runtime pack version provided by the SDK).

Note: Do not merge yet, I opened [this PR](https://github.com/azambrano/JsonDocumentPath/pull/2) to the JsonDocumentPath dependency as well and hopefully they can ship a new release with the changes to remove S.T.J package reference when using .NET 6+.