### PR TITLE
Fix wrong bitwise operator used in ColorConverter

### DIFF
--- a/Remora.Rest/Json/ColorConverter.cs
+++ b/Remora.Rest/Json/ColorConverter.cs
@@ -41,7 +41,7 @@ public class ColorConverter : JsonConverter<Color>
         }
 
         var value = reader.GetUInt32();
-        var clrValue = value ^ 0xFF000000;
+        var clrValue = value | 0xFF000000;
 
         return Color.FromArgb((int)clrValue);
     }


### PR DESCRIPTION
This PR fixes an operation in ColorConverter.Read to convert an integer from RGB to ARGB (copying the color and setting the alpha channel to 255) which mistakenly uses a XOR operator, albeit coincidentally valid, instead of an OR. Although it doesn't cause issues with Discord's current API model, it could fail with larger values.