### PR TITLE
Check for 204 No Content status

### DIFF
--- a/Remora.Rest/Http/RestHttpClient.cs
+++ b/Remora.Rest/Http/RestHttpClient.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
@@ -601,7 +602,7 @@ public class RestHttpClient<TError> : IRestHttpClient
     {
         if (response.IsSuccessStatusCode)
         {
-            if (response.Content.Headers.ContentLength == 0)
+            if (response.Content.Headers.ContentLength == 0 || response.StatusCode == HttpStatusCode.NoContent)
             {
                 if (!allowNullReturn)
                 {


### PR DESCRIPTION
When a response returns the status "204 No Content" the unpacking of a response fails due to the absence of the Content-Length header.