### PR TITLE
Use LINQ Expressions in DataObjectConverter to theoretically improve performance

### DIFF
--- a/Remora.Rest/Json/DataObjectConverter.cs
+++ b/Remora.Rest/Json/DataObjectConverter.cs
@@ -43,7 +43,6 @@ namespace Remora.Rest.Json;
 public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TInterface>
     where TImplementation : TInterface
 {
-    private readonly ConstructorInfo _dtoConstructor;
     private readonly ObjectFactory<TInterface> _dtoFactory;
 
     private readonly IReadOnlyList<PropertyInfo> _dtoProperties;
@@ -87,10 +86,10 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
         var implementationType = typeof(TImplementation);
         var visibleProperties = implementationType.GetPublicProperties().ToArray();
 
-        _dtoConstructor = FindBestMatchingConstructor(visibleProperties);
-        _dtoFactory = ExpressionFactoryUtilities.CreateFactory<TInterface>(_dtoConstructor);
+        var dtoConstructor = FindBestMatchingConstructor(visibleProperties);
+        _dtoFactory = ExpressionFactoryUtilities.CreateFactory<TInterface>(dtoConstructor);
 
-        _dtoProperties = ReorderProperties(visibleProperties, _dtoConstructor);
+        _dtoProperties = ReorderProperties(visibleProperties, dtoConstructor);
 
         _dtoPropertyAccessors = _dtoProperties
             .ToDictionary

--- a/Remora.Rest/Json/DataObjectConverter.cs
+++ b/Remora.Rest/Json/DataObjectConverter.cs
@@ -52,7 +52,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
     private readonly IReadOnlyDictionary<PropertyInfo, InstancePropertyGetter> _dtoPropertyAccessors;
 
     // Empty optionals for all properties of type Optional<T> (for polyfilling default values)
-    private readonly IReadOnlyDictionary<Type, object?> _dtoEmptyOptionalFactories;
+    private readonly IReadOnlyDictionary<Type, object?> _dtoEmptyOptionals;
 
     private readonly Dictionary<PropertyInfo, string[]> _readNameOverrides;
     private readonly Dictionary<PropertyInfo, string> _writeNameOverrides;
@@ -99,7 +99,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
                 p => ExpressionFactoryUtilities.CreatePropertyGetter(p.DeclaringType ?? throw new InvalidOperationException(), p)
             );
 
-        _dtoEmptyOptionalFactories = _dtoProperties
+        _dtoEmptyOptionals = _dtoProperties
             .Select(p => p.PropertyType)
             .Where(t => t.IsOptional())
             .Distinct()
@@ -586,7 +586,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
             {
                 if (dtoProperty.PropertyType.IsOptional())
                 {
-                    propertyValue = _dtoEmptyOptionalFactories[dtoProperty.PropertyType];
+                    propertyValue = _dtoEmptyOptionals[dtoProperty.PropertyType];
                 }
                 else
                 {

--- a/Remora.Rest/Json/DataObjectConverter.cs
+++ b/Remora.Rest/Json/DataObjectConverter.cs
@@ -88,7 +88,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
         var visibleProperties = implementationType.GetPublicProperties().ToArray();
 
         _dtoConstructor = FindBestMatchingConstructor(visibleProperties);
-        _dtoFactory = FactoryFactory.CreateFactory<TInterface>(_dtoConstructor);
+        _dtoFactory = ExpressionFactoryUtilities.CreateFactory<TInterface>(_dtoConstructor);
 
         _dtoProperties = ReorderProperties(visibleProperties, _dtoConstructor);
 
@@ -96,7 +96,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
             .ToDictionary
             (
                 p => p,
-                p => FactoryFactory.CreatePropertyGetter(p.DeclaringType ?? throw new InvalidOperationException(), p)
+                p => ExpressionFactoryUtilities.CreatePropertyGetter(p.DeclaringType ?? throw new InvalidOperationException(), p)
             );
 
         _dtoEmptyOptionalFactories = _dtoProperties

--- a/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
+++ b/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
@@ -1,5 +1,5 @@
 ﻿//
-//  FactoryFactory.cs
+//  ExpressionFactoryUtilities.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>

--- a/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
+++ b/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
@@ -55,7 +55,7 @@ internal delegate object InstancePropertyGetter(object instance);
 /// Handles creation of delegates for performing reflective operations using Linq Expressions as a substitute for
 /// traditional reflection APIs using runtime-compiled .NET IL.
 /// </summary>
-internal static class FactoryFactory
+internal static class ExpressionFactoryUtilities
 {
     /// <summary>
     /// Creates an <see cref="ObjectFactory{T}"/> for the given type <typeparamref name="T"/> using the constructor

--- a/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
+++ b/Remora.Rest/Json/Reflection/ExpressionFactoryUtilities.cs
@@ -52,8 +52,8 @@ internal delegate T ObjectFactory<out T>(params object?[] args);
 internal delegate object InstancePropertyGetter(object instance);
 
 /// <summary>
-/// Handles creation of delegates for performing reflective operations using Linq Expressions as a substitute for
-/// traditional reflection APIs using runtime-compiled .NET IL.
+/// Handles application-specific creation of delegates for performing reflective operations using Linq Expressions as a
+/// substitute for traditional reflection APIs using runtime-compiled .NET IL.
 /// </summary>
 internal static class ExpressionFactoryUtilities
 {
@@ -105,7 +105,8 @@ internal static class ExpressionFactoryUtilities
          *     ...
          * );
          */
-        return Expression.Lambda<ObjectFactory<T>>(
+        return Expression.Lambda<ObjectFactory<T>>
+        (
             Expression.New(constructor, parameters),
             arguments
         ).Compile();
@@ -154,7 +155,8 @@ internal static class ExpressionFactoryUtilities
         /*
          * (instance) => (object) ((InstanceType)instance).property
          */
-        return Expression.Lambda<InstancePropertyGetter>(
+        return Expression.Lambda<InstancePropertyGetter>
+        (
             Expression.Convert(Expression.Property(Expression.Convert(instance, type), property), typeof(object)),
             instance
         ).Compile();

--- a/Remora.Rest/Json/Reflection/FactoryFactory.cs
+++ b/Remora.Rest/Json/Reflection/FactoryFactory.cs
@@ -1,0 +1,162 @@
+﻿//
+//  FactoryFactory.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Remora.Rest.Reflection;
+
+/// <summary>
+/// Represents a typeless factory that invokes the parameterless constructor of an unspecified type and returns the new
+/// instance cast to <c>object</c>.
+/// </summary>
+/// <returns>The newly created object.</returns>
+internal delegate object ParameterlessObjectFactory();
+
+/// <summary>
+/// Represents a factory that invokes a predefined constructor of type <typeparamref name="T"/> or a subclass thereof,
+/// without requiring a strongly-typed invocation.
+/// </summary>
+/// <param name="args">The positional arguments to pass to the constructor.</param>
+/// <typeparam name="T">The type of the object to instantiate.</typeparam>
+/// <returns>The newly created object.</returns>
+internal delegate T ObjectFactory<out T>(params object?[] args);
+
+/// <summary>
+/// Represents a typeless function that retrieves a predefined property from a predefined type using the instance given
+/// in <paramref name="instance"/> and returns it cast to <c>object</c>.
+/// </summary>
+/// <param name="instance">The instance whose property to retrieve.</param>
+/// <returns>The retrieved property.</returns>
+internal delegate object InstancePropertyGetter(object instance);
+
+/// <summary>
+/// Handles creation of delegates for performing reflective operations using Linq Expressions as a substitute for
+/// traditional reflection APIs using runtime-compiled .NET IL.
+/// </summary>
+internal static class FactoryFactory
+{
+    /// <summary>
+    /// Creates an <see cref="ObjectFactory{T}"/> for the given type <typeparamref name="T"/> using the constructor
+    /// <paramref name="constructor"/>.
+    /// </summary>
+    /// <param name="constructor">The constructor to be used to create the instance.</param>
+    /// <typeparam name="T">The type of the instance to create.</typeparam>
+    /// <returns>A factory that can be used to create instances of the specified type.</returns>
+    /// <exception cref="ArgumentException">
+    /// If the type <typeparamref name="T"/> is not assignable to the declaring type of the constructor, or the
+    /// constructor does not belong to a type.
+    /// </exception>
+    public static ObjectFactory<T> CreateFactory<T>(ConstructorInfo constructor)
+    {
+        if (constructor.DeclaringType == null)
+        {
+            throw new ArgumentException
+            (
+                $"Constructor does not belong to a type",
+                nameof(constructor)
+            );
+        }
+
+        if (constructor.DeclaringType.IsAssignableFrom(typeof(T)))
+        {
+            throw new ArgumentException
+            (
+                $"Constructor does not belong to a type corresponding to {nameof(T)}",
+                nameof(constructor)
+            );
+        }
+
+        var arguments = Expression.Parameter(typeof(object[]), "arguments");
+
+        var parameters = constructor.GetParameters()
+            .Select((p, i) => Expression.Convert
+                (
+                    Expression.ArrayIndex(arguments, Expression.Constant(i)),
+                    p.ParameterType
+                )
+            );
+
+        /*
+         * (object[] arguments) => new constructor(
+         *     (Param0Type) arguments[0],
+         *     (Param1Type) arguments[1],
+         *     ...
+         * );
+         */
+        return Expression.Lambda<ObjectFactory<T>>(
+            Expression.New(constructor, parameters),
+            arguments
+        ).Compile();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ParameterlessObjectFactory"/> for the given type <paramref name="type"/>, using the type's
+    /// public parameterless constructor.
+    /// </summary>
+    /// <param name="type">The type whose instances will be created by the factory.</param>
+    /// <returns>A factory that can be used to create instances of the specified type.</returns>
+    /// <exception cref="ArgumentException">
+    /// If the type <paramref name="type"/> does not have a public parameterless constructor.
+    /// </exception>
+    public static ParameterlessObjectFactory CreateFactoryParameterless(Type type)
+    {
+        var constructor = type.GetConstructor(Array.Empty<Type>()) ?? throw new ArgumentException
+        (
+            "Type did not have a public parameterless constructor",
+            nameof(type)
+        );
+
+        /*
+         * () => new constructor();
+         */
+        return Expression.Lambda<ParameterlessObjectFactory>(Expression.New(constructor)).Compile();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="InstancePropertyGetter"/> that retrieves the property <paramref name="property"/> in the
+    /// type <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type the factory will convert the instance to when retrieving the property.</param>
+    /// <param name="property">The property whose value will be retrieved by the factory.</param>
+    /// <returns>A factory that can be used to retrieve the specified property from a given instance.</returns>
+    /// <remarks>
+    /// We allow for manually specifying the <paramref name="type"/> instead of simply using
+    /// <see cref="MemberInfo.DeclaringType"/> because the instance is converted to that type specifically when
+    /// retrieving the property, and this doesn't necessarily have to align with the declaring type of the property, e.g
+    /// for edge cases such as explicit interface implementations.
+    /// </remarks>
+    public static InstancePropertyGetter CreatePropertyGetter(Type type, PropertyInfo property)
+    {
+        var instance = Expression.Parameter(typeof(object), "instance");
+
+        /*
+         * (instance) => (object) ((InstanceType)instance).property
+         */
+        return Expression.Lambda<InstancePropertyGetter>(
+            Expression.Convert(Expression.Property(Expression.Convert(instance, type), property), typeof(object)),
+            instance
+        ).Compile();
+    }
+}

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/INonConventionalData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/INonConventionalData.cs
@@ -1,0 +1,34 @@
+﻿//
+//  INonConventionalData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data interface that does not contain any complex members.
+/// </summary>
+public interface INonConventionalData
+{
+    /// <summary>
+    /// Gets an arbitrary string.
+    /// </summary>
+    string Value { get; }
+}

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/NonConventionalData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/NonConventionalData.cs
@@ -1,0 +1,38 @@
+﻿//
+//  NonConventionalData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data class that serves as an implementation for <see cref="INonConventionalData"/>.
+/// </summary>
+public record NonConventionalData(string Value) : INonConventionalData;
+
+/// <summary>
+/// A data class that unconventionally alters the type of the interface's property.
+/// </summary>
+/// <param name="Value">Gets an arbitrary string.</param>
+public record NonConventionalData2(string Value) : INonConventionalData
+{
+    /// <inheritdoc/>
+    string INonConventionalData.Value { get; } = "this should be serialized";
+}

--- a/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
+++ b/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
@@ -29,6 +29,9 @@
       <Compile Update="Data\DataObjects\IReadOnlyData.cs">
         <DependentUpon>ReadOnlyData.cs</DependentUpon>
       </Compile>
+      <Compile Update="Data\DataObjects\INonConventionalData.cs">
+        <DependentUpon>NonConventionalData.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
+++ b/Tests/Remora.Rest.Tests/Tests/Json/DataObjectConverterTests.cs
@@ -396,4 +396,30 @@ public class DataObjectConverterTests
         var serialized = JsonDocument.Parse(JsonSerializer.Serialize(value, jsonOptions));
         JsonAssert.Equivalent(expectedPayload, serialized);
     }
+
+    /// <summary>
+    /// Tests whether the converter can serialize a data object containing unconventional explicit interface
+    /// implementations.
+    /// </summary>
+    [Fact]
+    public void CanSerializeExplicitInterfaceImplementations()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddDataObjectConverter<INonConventionalData, NonConventionalData>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+
+        INonConventionalData value = new NonConventionalData2("this should not be serialized");
+        var expectedPayload = JsonDocument.Parse("{ \"value\": \"this should be serialized\" }");
+
+        var serialized = JsonDocument.Parse(JsonSerializer.Serialize(value, jsonOptions));
+        JsonAssert.Equivalent(expectedPayload, serialized);
+    }
 }


### PR DESCRIPTION
This PR migrates the DataObjectConverter to use compiled LINQ Expression Trees instead of traditional reflection to reduce overhead when calling property getters or invoking primary constructors.

I checked the unit tests for Remora.Discord.API.Tests and they all passed. I have not written benchmarks (yet). I am very sleepy.