### PR TITLE
Object-aware OneOfConverter

### DIFF
--- a/Remora.Rest/AssemblyAttributes.cs
+++ b/Remora.Rest/AssemblyAttributes.cs
@@ -1,0 +1,25 @@
+//
+//  AssemblyAttributes.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Remora.Rest.Tests")]

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/ComplexOneOfData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/ComplexOneOfData.cs
@@ -1,0 +1,31 @@
+//
+//  ComplexOneOfData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using OneOf;
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data record that contains an optional member.
+/// </summary>
+/// <param name="Value">An optional string.</param>
+public record ComplexOneOfData(OneOf<ApplicationCommandData, MessageComponentData> Value) : IComplexOneOfData;

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/IComplexOneOfData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/IComplexOneOfData.cs
@@ -1,0 +1,63 @@
+//
+//  IComplexOneOfData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using OneOf;
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data interface that contains a OneOf member.
+/// </summary>
+public interface IComplexOneOfData
+{
+    /// <summary>
+    /// Gets an optional string.
+    /// </summary>
+    OneOf<ApplicationCommandData, MessageComponentData> Value { get; }
+}
+
+/// <summary>
+/// A sister object for the <see cref="IComplexOneOfData"/> type.
+/// </summary>
+/// <param name="ID">An ID value.</param>
+/// <param name="Name">A name value.</param>
+/// <param name="Type">A type value.</param>
+/// <param name="Options">A list of option values.</param>
+public record ApplicationCommandData
+(
+    ulong ID,
+    string Name,
+    int Type,
+    IReadOnlyList<string> Options
+);
+
+/// <summary>
+/// A sister object for the <see cref="IComplexOneOfData"/> type.
+/// </summary>
+/// <param name="CustomID">An ID value.</param>
+/// <param name="ComponentType">A type value.</param>
+public record MessageComponentData
+(
+    string CustomID,
+    int ComponentType
+);

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/ISimpleOneOfData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/ISimpleOneOfData.cs
@@ -1,0 +1,36 @@
+//
+//  ISimpleOneOfData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using OneOf;
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data interface that contains a OneOf member.
+/// </summary>
+public interface ISimpleOneOfData
+{
+    /// <summary>
+    /// Gets an optional string.
+    /// </summary>
+    OneOf<string, int> Value { get; }
+}

--- a/Tests/Remora.Rest.Tests/Data/DataObjects/SimpleOneOfData.cs
+++ b/Tests/Remora.Rest.Tests/Data/DataObjects/SimpleOneOfData.cs
@@ -1,0 +1,31 @@
+//
+//  SimpleOneOfData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using OneOf;
+
+namespace Remora.Rest.Tests.Data.DataObjects;
+
+/// <summary>
+/// A data record that contains an optional member.
+/// </summary>
+/// <param name="Value">An optional string.</param>
+public record SimpleOneOfData(OneOf<string, int> Value) : ISimpleOneOfData;

--- a/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
+++ b/Tests/Remora.Rest.Tests/Remora.Rest.Tests.csproj
@@ -29,6 +29,12 @@
       <Compile Update="Data\DataObjects\IReadOnlyData.cs">
         <DependentUpon>ReadOnlyData.cs</DependentUpon>
       </Compile>
+      <Compile Update="Data\DataObjects\IComplexOneOfData.cs">
+        <DependentUpon>ComplexOneOfData.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Data\DataObjects\ISimpleOneOfData.cs">
+        <DependentUpon>SimpleOneOfData.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Rest.Tests/Tests/Json/OneOfConverterTests.cs
+++ b/Tests/Remora.Rest.Tests/Tests/Json/OneOfConverterTests.cs
@@ -1,0 +1,100 @@
+//
+//  OneOfConverterTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Remora.Rest.Extensions;
+using Remora.Rest.Json.Internal;
+using Remora.Rest.Json.Policies;
+using Remora.Rest.Tests.Data.DataObjects;
+using Xunit;
+
+namespace Remora.Rest.Tests.Json;
+
+/// <summary>
+/// Tests the <see cref="OneOfConverter{TOneOf}"/> class.
+/// </summary>
+public class OneOfConverterTests
+{
+    /// <summary>
+    /// Tests whether the converter can deserialize a OneOf object containing primitive types.
+    /// </summary>
+    [Fact]
+    public void CanDeserializeSimpleObject()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddConverter<OneOfConverterFactory>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+        var payload = "{ \"value\": \"booga\" }";
+
+        var valueMaybeNull = JsonSerializer.Deserialize<SimpleOneOfData>(payload, jsonOptions);
+        Assert.NotNull(valueMaybeNull);
+
+        var value = valueMaybeNull!.Value;
+        Assert.True(value.IsT0);
+        Assert.Equal("booga", value.AsT0);
+
+        payload = "{ \"value\": 10 }";
+        valueMaybeNull = JsonSerializer.Deserialize<SimpleOneOfData>(payload, jsonOptions);
+        Assert.NotNull(valueMaybeNull);
+
+        value = valueMaybeNull!.Value;
+        Assert.True(value.IsT1);
+        Assert.Equal(10, value.AsT1);
+    }
+
+    /// <summary>
+    /// Tests whether the converter can deserialize a OneOf object containing objects.
+    /// </summary>
+    [Fact]
+    public void CanDeserializeComplexObject()
+    {
+        var services = new ServiceCollection()
+            .Configure<JsonSerializerOptions>
+            (
+                json =>
+                {
+                    json.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+                    json.AddConverter<OneOfConverterFactory>();
+                })
+            .BuildServiceProvider();
+
+        var jsonOptions = services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
+        var payload = "{ \"value\": { \"custom_id\": \"Next\", \"component_type\": 2 } }";
+
+        var valueMaybeNull = JsonSerializer.Deserialize<ComplexOneOfData>(payload, jsonOptions);
+        Assert.NotNull(valueMaybeNull);
+
+        var value = valueMaybeNull!.Value;
+        Assert.True(value.IsT1);
+        Assert.Equal(new MessageComponentData("Next", 2), value.AsT1);
+    }
+}


### PR DESCRIPTION
The current OneOfConverter fails to process JSON object tokens. It attempts to deserialize every union member type, and if a type succeeds this is considered to be the correct value. Because member types are deserializing without error in some cases, despite not matching the shape of the provided JSON, the converter is returning an incorrect value.

This PR attempts to resolve this using the following logic:

- Names of any non-optional property on the union members types are cached.
- Upon being requested to deserialize a JSON object node, a `JsonDocument` is created.
- The property names of cached member types are sequentially checked to ensure they exist in the document.
- The first type in which all the property names are present is considered to be correct, and the document is deserialized.

It's not a particularly efficient mechanism. As far as I can tell the limitations on the `Utf8JsonReader` prevent peeking forward to look at the shape, which is why I've chosen this route. Very open to suggestions.