### PR TITLE
Do not throw InvalidOperationException during DataObject deserialization

### DIFF
--- a/Remora.Rest/Json/DataObjectConverter.cs
+++ b/Remora.Rest/Json/DataObjectConverter.cs
@@ -615,7 +615,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
                 }
                 else
                 {
-                    throw new InvalidOperationException
+                    throw new JsonException
                     (
                         $"The data property \"{dtoProperty.Name}\" did not have a corresponding value in the JSON."
                     );
@@ -720,7 +720,7 @@ public class DataObjectConverter<TInterface, TImplementation> : JsonConverter<TI
             {
                 if (!innerType.IsGenericType)
                 {
-                    throw new InvalidOperationException("The innermost type of the property isn't an enum.");
+                    throw new JsonException("The innermost type of the property isn't an enum.");
                 }
 
                 innerType = innerType.GetGenericArguments()[0];


### PR DESCRIPTION
This fixes the OneOfConverter not working with recent changes to the DataObjectConverter.
The reason this doesn't work is because OneOfConverter assumes the JsonConverter will throw a `JsonException` for unmatching types:

https://github.com/Nihlus/Remora.Rest/blob/124dc0a6de5f77db5df4388e3389aec8c18bfe1b/Remora.Rest/Json/Internal/OneOfConverter.cs#L140-L148

This is a reasonable assumption to make, so I changed the DataObjectConverter's throw statements to JsonException.