### PR TITLE
Fix .ToObject<T> throwing due to writer cache

### DIFF
--- a/Remora.Rest/Extensions/JsonExtensions.cs
+++ b/Remora.Rest/Extensions/JsonExtensions.cs
@@ -34,7 +34,7 @@ public static class JsonExtensions
         using var writer = new Utf8JsonWriter(bufferWriter);
         element.WriteTo(writer);
 
-        element.Flush();
+        writer.Flush();
 
         return JsonSerializer.Deserialize<TEntity>(bufferWriter.WrittenSpan, options);
     }

--- a/Remora.Rest/Extensions/JsonExtensions.cs
+++ b/Remora.Rest/Extensions/JsonExtensions.cs
@@ -34,6 +34,8 @@ public static class JsonExtensions
         using var writer = new Utf8JsonWriter(bufferWriter);
         element.WriteTo(writer);
 
+        element.Flush();
+
         return JsonSerializer.Deserialize<TEntity>(bufferWriter.WrittenSpan, options);
     }
 


### PR DESCRIPTION
See commit details - this bug was brought to my attention when attempting to monkey-patch https://github.com/Remora/Remora.Discord/pull/338